### PR TITLE
Force Openscenegraph to use QT4 and add an installation checker script

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -96,7 +96,7 @@ gepetto-viewer-corba_repository=${HPP_REPO}
 hpp-gepetto-viewer_branch=devel
 hpp-gepetto-viewer_repository=${HPP_REPO}
 
-OpenSceneGraph-3.4.0_extra_flags= -DCOLLADA_DYNAMIC_LIBRARY=${DEVEL_DIR}/install/lib/libcollada14dom.so -DCOLLADA_INCLUDE_DIR=${DEVEL_DIR}/install/include/collada-dom -DLIB_POSTFIX=""
+OpenSceneGraph-3.4.0_extra_flags= -DDESIRED_QT_VERSION=4 -DCOLLADA_DYNAMIC_LIBRARY=${DEVEL_DIR}/install/lib/libcollada14dom.so -DCOLLADA_INCLUDE_DIR=${DEVEL_DIR}/install/include/collada-dom -DLIB_POSTFIX=""
 
 all: hpp_tutorial.install \
 	hpp-gepetto-viewer.install

--- a/script/auto-install-hpp.sh
+++ b/script/auto-install-hpp.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+BRANCH=devel
+if [ -z ${DEVEL_DIR} ]; then
+  export DEVEL_DIR=/local/devel/hpp
+fi
+
+# Add ros repositories
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116
+
+sudo sh -c 'echo "deb http://archive.ubuntu.com/ubuntu trusty universe" > /etc/apt/sources.list.d/trusty-universe.list'
+
+sudo apt-get update && sudo apt-get --assume-yes upgrade
+
+# Install dependencies
+
+# FIXME: I do not know why this is not in the installed Ubuntu. Is wget missing in Ubuntu 14.04 
+# or is it deboostrap that is not installing the good version ?
+sudo apt-get --assume-yes install wget
+# This is required by OpenSceneGraph and is usually installed with Ubuntu 14.04 and graphic card
+# drivers.
+sudo apt-get --assume-yes install doxygen freeglut3-dev
+
+# From here, it is a standard HPP installation
+sudo apt-get --assume-yes install autoconf g++ cmake libboost-dev liburdfdom-dev libassimp-dev ros-indigo-xacro ros-indigo-kdl-parser ros-indigo-common-msgs ros-indigo-tf ros-indigo-tf-conversions ros-indigo-libccd ros-indigo-octomap ros-indigo-resource-retriever ros-indigo-srdfdom ros-indigo-pr2-robot flex bison asciidoc source-highlight git libomniorb4-dev omniorb-nameserver omniidl omniidl-python libltdl-dev python-matplotlib libtinyxml2-dev
+sudo apt-get --assume-yes build-dep openscenegraph
+
+# Setup environment
+mkdir --parents $DEVEL_DIR
+mkdir --parents $DEVEL_DIR/src
+mkdir --parents $DEVEL_DIR/install
+
+# Get config script
+wget -O $DEVEL_DIR/config.sh https://raw.githubusercontent.com/humanoid-path-planner/hpp-doc/${BRANCH}/doc/config.sh
+wget -O $DEVEL_DIR/src/Makefile https://raw.githubusercontent.com/humanoid-path-planner/hpp-doc/${BRANCH}/doc/Makefile
+
+source $DEVEL_DIR/config.sh
+
+cd $DEVEL_DIR/src
+
+make robot_state_chain_publisher.install
+source ../config.sh
+make all

--- a/script/check-install.sh
+++ b/script/check-install.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# read arguments
+if [ $# -ne 1 ] && [ $# -ne 2 ]; then
+  echo "usage: $0 <install-directory> <bash_script_to_launch>"
+  exit 1
+fi
+
+DST="$1"
+if [ $# -eq 2 ]; then
+  SCRIPT="$2"
+else
+  HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+  SCRIPT="$HERE/auto-install-hpp.sh"
+fi
+
+if [ -f ${SCRIPT} -a -r ${SCRIPT} ]; then
+  echo "Will run '/bin/bash ${SCRIPT}' in the fresh install."
+else
+  echo "${SCRIPT} not found"
+  exit 1
+fi
+
+RUN=`basename "${SCRIPT}"`
+
+# install ubuntu
+debootstrap trusty "$DST"
+
+# put the installation script in the fresh install
+cp "${SCRIPT}" "$DST/root/$RUN"
+
+chroot "${DST}" /bin/bash "/root/$RUN"


### PR DESCRIPTION
One can check the installation works properly by running
```sh
sudo ./check-install.sh /local/devel/hpp-check
```
Warning: it takes some time.