### PR TITLE
Change DEVEL_DIR to DEVEL_HPP_DIR and INSTALL_DIR to INSTALL_HPP_DIR

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,8 +10,10 @@ HPP_REPO=https://github.com/humanoid-path-planner
 SOT_REPO=https://github.com/stack-of-tasks
 RETHINK_ROBOTICS_REPO=https://github.com/RethinkRobotics
 
-SRC_DIR=${DEVEL_DIR}/src
-INSTALL_DIR=${DEVEL_DIR}/install
+SRC_DIR=${DEVEL_HPP_DIR}/src
+ifndef INSTALL_HPP_DIR
+INSTALL_HPP_DIR=${DEVEL_HPP_DIR}/install
+endif
 
 # Whether to compute humanoid specific part
 HUMANOID=TRUE
@@ -164,8 +166,8 @@ hpp_romeo_repository=${HPP_REPO}
 romeo_branch=master
 romeo_repository=${HPP_REPO}
 
-OpenSceneGraph-dae-plugin_extra_flags= -DCOLLADA_DYNAMIC_LIBRARY=${INSTALL_DIR}/lib/libcollada14dom.so -DCOLLADA_INCLUDE_DIR=${INSTALL_DIR}/include/collada-dom
-OpenSceneGraph-3.4.0_extra_flags= -DDESIRED_QT_VERSION=${QT_VERSION} -DCOLLADA_DYNAMIC_LIBRARY=${INSTALL_DIR}/lib/libcollada14dom.so -DCOLLADA_INCLUDE_DIR=${INSTALL_DIR}/include/collada-dom -DLIB_POSTFIX=""
+OpenSceneGraph-dae-plugin_extra_flags= -DCOLLADA_DYNAMIC_LIBRARY=${INSTALL_HPP_DIR}/lib/libcollada14dom.so -DCOLLADA_INCLUDE_DIR=${INSTALL_HPP_DIR}/include/collada-dom
+OpenSceneGraph-3.4.0_extra_flags= -DDESIRED_QT_VERSION=${QT_VERSION} -DCOLLADA_DYNAMIC_LIBRARY=${INSTALL_HPP_DIR}/lib/libcollada14dom.so -DCOLLADA_INCLUDE_DIR=${INSTALL_HPP_DIR}/include/collada-dom -DLIB_POSTFIX=""
 
 collada-dom_extra_flags=-DBUILD_SHARED_LIBS=TRUE -DOPT_COLLADA15=FALSE
 
@@ -186,7 +188,7 @@ endif
 all: hpp_tutorial.install hpp-gepetto-viewer.install
 	${MAKE} hpp-doc.install
 
-# source $DEVEL_DIR/install/setup.bash before installing hrp2.
+# source $DEVEL_HPP_DIR/install/setup.bash before installing hrp2.
 hrp2: test-hpp.install
 
 hpp-doc.configure.dep: hpp-doc.checkout
@@ -326,7 +328,7 @@ update:
 %.configure_nodep:%.checkout
 	mkdir -p ${SRC_DIR}/$(@:.configure_nodep=)/${BUILD_FOLDER}; \
 	cd ${SRC_DIR}/$(@:.configure_nodep=)/${BUILD_FOLDER}; \
-	cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+	cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_HPP_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
 			-DINSTALL_DOCUMENTATION=${INSTALL_DOCUMENTATION} \
 			-DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -DNDEBUG" \
 			${$(@:.configure_nodep=)_extra_flags} ..
@@ -380,11 +382,11 @@ roboptim-trajectory-3.1.checkout:
 	fi
 
 hrp2.configure: hrp2.configure.dep
-	. ${INSTALL_DIR}/setup.sh; \
+	. ${INSTALL_HPP_DIR}/setup.sh; \
 	cd ${SRC_DIR}/hrp2/hrp2_14_description;\
 	mkdir -p ${BUILD_FOLDER}; \
 	cd ${SRC_DIR}/hrp2/hrp2_14_description/${BUILD_FOLDER}; \
-	cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
+	cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_HPP_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 
 hrp2.install: hrp2.configure
 	${MAKE} -C ${SRC_DIR}/hrp2/hrp2_14_description/${BUILD_FOLDER} install
@@ -393,11 +395,11 @@ robot_model_py.configure: robot_model_py.configure.dep
 	cd ${SRC_DIR}/$(@:.configure=)/xml_reflection;\
 	mkdir -p ${BUILD_FOLDER}; \
 	cd ${BUILD_FOLDER}; \
-	cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
+	cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_HPP_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 	cd ${SRC_DIR}/$(@:.configure=)/urdf_parser_py;\
 	mkdir -p ${BUILD_FOLDER}; \
 	cd ${BUILD_FOLDER}; \
-	cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
+	cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_HPP_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 
 robot_model_py.install: robot_model_py.configure
 	${MAKE} -C ${SRC_DIR}/$(@:.install=)/xml_reflection/${BUILD_FOLDER} install; \
@@ -406,7 +408,7 @@ robot_model_py.install: robot_model_py.configure
 universal_robot.configure_nodep:
 	mkdir -p ${SRC_DIR}/$(@:.configure_nodep=)/ur_description/${BUILD_FOLDER}; \
 	cd ${SRC_DIR}/$(@:.configure_nodep=)/ur_description/${BUILD_FOLDER}; \
-	cmake -DCMAKE_INSTALL_PREFIX=${DEVEL_DIR}/install -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -DNDEBUG" ${$(@:.configure_nodep=)_extra_flags} ..
+	cmake -DCMAKE_INSTALL_PREFIX=${DEVEL_HPP_DIR}/install -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -DNDEBUG" ${$(@:.configure_nodep=)_extra_flags} ..
 
 universal_robot.install_nodep:universal_robot.configure_nodep
 	cd ${SRC_DIR}/$(@:.install_nodep=)/ur_description/${BUILD_FOLDER};\
@@ -419,10 +421,10 @@ universal_robot.install:universal_robot.configure
 baxter_common.configure_nodep:
 	mkdir -p ${SRC_DIR}/$(@:.configure_nodep=)/baxter_description/${BUILD_FOLDER}; \
 	cd ${SRC_DIR}/$(@:.configure_nodep=)/baxter_description/${BUILD_FOLDER}; \
-	cmake -DCMAKE_INSTALL_PREFIX=${DEVEL_DIR}/install -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -DNDEBUG" ${$(@:.configure_nodep=)_extra_flags} ..; \
+	cmake -DCMAKE_INSTALL_PREFIX=${DEVEL_HPP_DIR}/install -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -DNDEBUG" ${$(@:.configure_nodep=)_extra_flags} ..; \
 	mkdir -p ${SRC_DIR}/$(@:.configure_nodep=)/rethink_ee_description/${BUILD_FOLDER}; \
 	cd ${SRC_DIR}/$(@:.configure_nodep=)/rethink_ee_description/${BUILD_FOLDER}; \
-	cmake -DCMAKE_INSTALL_PREFIX=${DEVEL_DIR}/install -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -DNDEBUG" ${$(@:.configure_nodep=)_extra_flags} ..
+	cmake -DCMAKE_INSTALL_PREFIX=${DEVEL_HPP_DIR}/install -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -DNDEBUG" ${$(@:.configure_nodep=)_extra_flags} ..
 
 baxter_common.install_nodep:baxter_common.configure_nodep
 	cd ${SRC_DIR}/$(@:.install_nodep=)/baxter_description/${BUILD_FOLDER};\
@@ -437,11 +439,11 @@ baxter_common.install:baxter_common.configure
 	make install
 
 romeo.configure: romeo.configure.dep
-	. ${INSTALL_DIR}/setup.sh; \
+	. ${INSTALL_HPP_DIR}/setup.sh; \
 	cd ${SRC_DIR}/romeo/romeo_description;\
 	mkdir -p ${BUILD_FOLDER}; \
 	cd ${SRC_DIR}/romeo/romeo_description/${BUILD_FOLDER}; \
-	cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
+	cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_HPP_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 
 romeo.install: romeo.configure
 	${MAKE} -C ${SRC_DIR}/romeo/romeo_description/${BUILD_FOLDER} install

--- a/doc/config/ubuntu-14.04-indigo.sh
+++ b/doc/config/ubuntu-14.04-indigo.sh
@@ -1,15 +1,15 @@
-export PATH=$DEVEL_DIR/install/sbin:$DEVEL_DIR/install/bin:/opt/ros/indigo/bin:$PATH
-export PKG_CONFIG_PATH=$DEVEL_DIR/install/lib/pkgconfig/:/opt/ros/indigo/lib/pkgconfig
+export PATH=$DEVEL_HPP_DIR/install/sbin:$DEVEL_HPP_DIR/install/bin:/opt/ros/indigo/bin:$PATH
+export PKG_CONFIG_PATH=$DEVEL_HPP_DIR/install/lib/pkgconfig/:/opt/ros/indigo/lib/pkgconfig
 
-export PYTHONPATH=$DEVEL_DIR/install/lib/python2.7/site-packages:$DEVEL_DIR/install/lib/python2.7/dist-packages:/opt/ros/indigo/lib/python2.7/dist-packages:$PYTHONPATH
+export PYTHONPATH=$DEVEL_HPP_DIR/install/lib/python2.7/site-packages:$DEVEL_HPP_DIR/install/lib/python2.7/dist-packages:/opt/ros/indigo/lib/python2.7/dist-packages:$PYTHONPATH
 
-export LD_LIBRARY_PATH=$DEVEL_DIR/install/lib:$DEVEL_DIR/install/lib64:/opt/ros/indigo/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$DEVEL_HPP_DIR/install/lib:$DEVEL_HPP_DIR/install/lib64:/opt/ros/indigo/lib:$LD_LIBRARY_PATH
 
-if [ -f $DEVEL_DIR/install/setup.bash ]; then
-    source $DEVEL_DIR/install/setup.bash
+if [ -f $DEVEL_HPP_DIR/install/setup.bash ]; then
+    source $DEVEL_HPP_DIR/install/setup.bash
 else
     source /opt/ros/indigo/setup.bash
 fi
 # Make sure that /opt/ros/indigo/setup.bash is in the ROS_PACKAGE_PATH,
 # otherwise, you should add it by hand in the line below.
-export ROS_PACKAGE_PATH=$DEVEL_DIR/install/share:$ROS_PACKAGE_PATH
+export ROS_PACKAGE_PATH=$DEVEL_HPP_DIR/install/share:$ROS_PACKAGE_PATH

--- a/doc/config/ubuntu-16.04-kinetic.sh
+++ b/doc/config/ubuntu-16.04-kinetic.sh
@@ -1,15 +1,15 @@
-export PATH=$DEVEL_DIR/install/sbin:$DEVEL_DIR/install/bin:/opt/ros/kinetic/bin:$PATH
-export PKG_CONFIG_PATH=$DEVEL_DIR/install/lib/pkgconfig/:/opt/ros/kinetic/lib/pkgconfig
+export PATH=$DEVEL_HPP_DIR/install/sbin:$DEVEL_HPP_DIR/install/bin:/opt/ros/kinetic/bin:$PATH
+export PKG_CONFIG_PATH=$DEVEL_HPP_DIR/install/lib/pkgconfig/:/opt/ros/kinetic/lib/pkgconfig
 
-export PYTHONPATH=$DEVEL_DIR/install/lib/python2.7/site-packages:$DEVEL_DIR/install/lib/python2.7/dist-packages:/opt/ros/kinetic/lib/python2.7/dist-packages:$PYTHONPATH
+export PYTHONPATH=$DEVEL_HPP_DIR/install/lib/python2.7/site-packages:$DEVEL_HPP_DIR/install/lib/python2.7/dist-packages:/opt/ros/kinetic/lib/python2.7/dist-packages:$PYTHONPATH
 
-export LD_LIBRARY_PATH=$DEVEL_DIR/install/lib:$DEVEL_DIR/install/lib64:/opt/ros/kinetic/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$DEVEL_HPP_DIR/install/lib:$DEVEL_HPP_DIR/install/lib64:/opt/ros/kinetic/lib:$LD_LIBRARY_PATH
 
-if [ -f $DEVEL_DIR/install/setup.bash ]; then
-    source $DEVEL_DIR/install/setup.bash
+if [ -f $DEVEL_HPP_DIR/install/setup.bash ]; then
+    source $DEVEL_HPP_DIR/install/setup.bash
 else
     source /opt/ros/kinetic/setup.bash
 fi
 # Make sure that /opt/ros/kinetic/setup.bash is in the ROS_PACKAGE_PATH,
 # otherwise, you should add it by hand in the line below.
-export ROS_PACKAGE_PATH=$DEVEL_DIR/install/share:$ROS_PACKAGE_PATH
+export ROS_PACKAGE_PATH=$DEVEL_HPP_DIR/install/share:$ROS_PACKAGE_PATH

--- a/doc/instructions.md
+++ b/doc/instructions.md
@@ -53,32 +53,32 @@ sudo apt-get install autoconf g++ cmake doxygen libboost-dev liburdfdom-dev liba
     ```
 
   3. Choose a directory on you file system and define the environment
-     variable `DEVEL_DIR` with the full path to this directory.
-     - the packages will be cloned into `$DEVEL_DIR/src`,
-     - the packages will be installed in `$DEVEL_DIR/install`.
-     It is recommanded to set variable `DEVEL_DIR` in your `.bashrc` for future use.
+     variable `DEVEL_HPP_DIR` with the full path to this directory.
+     - the packages will be cloned into `$DEVEL_HPP_DIR/src`,
+     - the packages will be installed in `$DEVEL_HPP_DIR/install`.
+     It is recommanded to set variable `DEVEL_HPP_DIR` in your `.bashrc` for future use.
 
     ```bash
-    mkdir -p $DEVEL_DIR/src
+    mkdir -p $DEVEL_HPP_DIR/src
     ```
   4. Copy Config and Makefile
 
     ```bash
-wget -O $DEVEL_DIR/config.sh https://raw.githubusercontent.com/humanoid-path-planner/hpp-doc/master/doc/config/ubuntu-16.04-kinetic.sh
-wget -O $DEVEL_DIR/src/Makefile https://raw.githubusercontent.com/humanoid-path-planner/hpp-doc/master/doc/Makefile
+wget -O $DEVEL_HPP_DIR/config.sh https://raw.githubusercontent.com/humanoid-path-planner/hpp-doc/master/doc/config/ubuntu-16.04-kinetic.sh
+wget -O $DEVEL_HPP_DIR/src/Makefile https://raw.githubusercontent.com/humanoid-path-planner/hpp-doc/master/doc/Makefile
     ```
 
-  5. cd into `$DEVEL_DIR` and type
+  5. cd into `$DEVEL_HPP_DIR` and type
 
     ```bash
-cd ${DEVEL_DIR}
+cd ${DEVEL_HPP_DIR}
 source config.sh
     ```
 
-  6. cd into `$DEVEL_DIR/src` and type
+  6. cd into `$DEVEL_HPP_DIR/src` and type
 
     ```bash
-cd ${DEVEL_DIR}/src
+cd ${DEVEL_HPP_DIR}/src
 make robot_state_chain_publisher.install;
 source ../config.sh;
 make all
@@ -86,5 +86,5 @@ make all
 
 ##Documentation
 
-  Open `$DEVEL_DIR/install/share/doc/hpp-doc/index.html` in a web brower and you
+  Open `$DEVEL_HPP_DIR/install/share/doc/hpp-doc/index.html` in a web brower and you
   will have access to the documentation of most packages.

--- a/script/README.md
+++ b/script/README.md
@@ -2,14 +2,14 @@
 
 To avoid conflicts, you must setup a clean environment,
 i.e. without having sourced the ROS `setup.bash` or the HPP `config.sh`.
-To create the tarball, HPP will be compiled in `$DEVEL_DIR` (defaults to `/local/devel/hpp`).
+To create the tarball, HPP will be compiled in `$DEVEL_HPP_DIR` (defaults to `/local/devel/hpp`).
 You may select the type of build you want using the environment variable `BUILD_TYPE`.
 
 If you sourced `config.sh`, this should be sufficient (although it is unsafe) to create a clean
 environment:
 ```bash
 export DEVEL_CONFIG="noconfig"
-unset PATH PYTHONPATH ROS_PACKAGE_PATH LD_LIBRARY_PATH CPATH DEVEL_DIR PKG_CONFIG_PATH CMAKE_PREFIX_PATH HPPCD_PATH
+unset PATH PYTHONPATH ROS_PACKAGE_PATH LD_LIBRARY_PATH CPATH DEVEL_HPP_DIR PKG_CONFIG_PATH CMAKE_PREFIX_PATH HPPCD_PATH
 /bin/bash
 ```
 
@@ -18,7 +18,7 @@ Build the tarball using
 auto-install-hpp.sh --mktar -v
 ```
 
-You will find three files in the directory `${DEVEL_DIR}/tarball/`:
+You will find three files in the directory `${DEVEL_HPP_DIR}/tarball/`:
 * a bash script called `check.***.sh` that should be used in order to resolve the dependencies on a new computer,
 * a tarball called `hpp.***.tar.gz` containing only the binaries,
 * a tarball called `hpp.src.***.tar.gz` containing the binaries and the source files.

--- a/script/auto-install-hpp.sh
+++ b/script/auto-install-hpp.sh
@@ -38,8 +38,8 @@ MAKE_TARBALL=false
 TARGET=all
 
 BRANCH=""
-if [ -z ${DEVEL_DIR} ]; then
-  export DEVEL_DIR=/local/devel/hpp
+if [ -z ${DEVEL_HPP_DIR} ]; then
+  export DEVEL_HPP_DIR=/local/devel/hpp
 fi
 if [ -z ${BUILD_TYPE} ]; then
   export BUILD_TYPE=Release
@@ -78,7 +78,7 @@ do
       exit 0
       ;;
     -v)
-      for v in "DEVEL_DIR" "BUILD_TYPE" "MAKE_TARBALL" "BRANCH"
+      for v in "DEVEL_HPP_DIR" "BUILD_TYPE" "MAKE_TARBALL" "BRANCH"
       do
         echo "$v=${!v}"
       done
@@ -111,29 +111,29 @@ sudo apt-get --assume-yes install ${APT_DEP}
 [[ -z $APT_BUILD_DEP ]] || sudo apt-get --assume-yes build-dep ${APT_BUILD_DEP}
 
 # Setup environment
-mkdir --parents $DEVEL_DIR
-mkdir --parents $DEVEL_DIR/src
-mkdir --parents $DEVEL_DIR/install
+mkdir --parents $DEVEL_HPP_DIR
+mkdir --parents $DEVEL_HPP_DIR/src
+mkdir --parents $DEVEL_HPP_DIR/install
 
 # Get config script
-wget -q -O $DEVEL_DIR/config.sh https://raw.githubusercontent.com/humanoid-path-planner/hpp-doc/${BRANCH}/doc/config/${CONFIG_FILE}
-wget -q -O $DEVEL_DIR/src/Makefile https://raw.githubusercontent.com/humanoid-path-planner/hpp-doc/${BRANCH}/doc/Makefile
+wget -q -O $DEVEL_HPP_DIR/config.sh https://raw.githubusercontent.com/humanoid-path-planner/hpp-doc/${BRANCH}/doc/config/${CONFIG_FILE}
+wget -q -O $DEVEL_HPP_DIR/src/Makefile https://raw.githubusercontent.com/humanoid-path-planner/hpp-doc/${BRANCH}/doc/Makefile
 
-source $DEVEL_DIR/config.sh
+source $DEVEL_HPP_DIR/config.sh
 
-cd $DEVEL_DIR/src
+cd $DEVEL_HPP_DIR/src
 
 make -s -e robot_state_chain_publisher.install
 source ../config.sh
 make -s -e $TARGET
 
 if [ ${MAKE_TARBALL} = true ]; then
-  cd $DEVEL_DIR/
+  cd $DEVEL_HPP_DIR/
   mkdir tarball
   SUFFIX="${BRANCH}-`date +%Y%m%d`-${BUILD_TYPE}"
   tar czf "tarball/hpp.src.${SUFFIX}.tar.gz" src/ install/ config.sh
   tar czf "tarball/hpp.${SUFFIX}.tar.gz" install/ config.sh
-  INSTALL="$DEVEL_DIR/tarball/check.${SUFFIX}.sh"
+  INSTALL="$DEVEL_HPP_DIR/tarball/check.${SUFFIX}.sh"
   echo "#!/bin/bash" > ${INSTALL}
   echo "# Dependencies" >> ${INSTALL}
   echo "sudo apt-get install $APT_DEP" >> ${INSTALL}

--- a/script/generate-tar-doc
+++ b/script/generate-tar-doc
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# generate-tar-doc $DEVEL_DIR/install/share/doc http://projects.laas.fr/gepetto/hpp
+# generate-tar-doc $DEVEL_HPP_DIR/install/share/doc http://projects.laas.fr/gepetto/hpp
 # then copy /tmp/hpp.tar.gz on server and inflate archive.
 
 usage="usage: `basename $0` <directory> <server>"

--- a/script/install-tar-on-remote
+++ b/script/install-tar-on-remote
@@ -41,7 +41,7 @@ function _confirm () {
 # Generate a tar ball and send it to the remote server.
 if [ ! -f /tmp/hpp.tar.gz ]; then
   echo "Generating tarball... (This may take a while)"
-  generate-tar-doc $DEVEL_DIR/install/share/doc $VERSIONURL
+  generate-tar-doc $DEVEL_HPP_DIR/install/share/doc $VERSIONURL
 else
   echo "Tarball already generated."
   _confirm "Should I use existing /tmp/hpp.tar.gz ?"


### PR DESCRIPTION
New naming convention to avoid clashes.
Test if INSTALL_HPP_DIR is already set, if not then use the standard approach.
The user can change the behavior by setting his own INSTALL_HPP_DIR.
Change DEVEL_HPP_DIR and INSTALL_HPP_DIR everywhere.