### PR TITLE
Add 18.04, use more packages from robotpkg, and update devel

### DIFF
--- a/.dockers/ubuntu-14.04/Dockerfile
+++ b/.dockers/ubuntu-14.04/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update -qqy && apt-get install -qqy \
 
 RUN echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list
 RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-RUN echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub trusty robotpkg" > /etc/apt/sources.list.d/robotpkg.list
+RUN echo "deb [arch=amd64] http://robotpkg.openrobots.org/wip/packages/debian/pub trusty robotpkg" > /etc/apt/sources.list.d/robotpkg.list
+RUN echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub trusty robotpkg" >> /etc/apt/sources.list.d/robotpkg.list
 RUN curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | apt-key add -
 
 RUN apt-get update -qqy && apt-get install -qqy \
@@ -36,10 +37,12 @@ RUN apt-get update -qqy && apt-get install -qqy \
     oxygen-icon-theme \
     python-matplotlib \
     qt4-dev-tools \
+    robotpkg-osg-dae \
     robotpkg-qpoases+doc \
     robotpkg-roboptim-core \
     robotpkg-roboptim-trajectory \
     robotpkg-romeo-description \
+    robotpkg-ros-baxter-common \
     ros-indigo-xacro \
     ros-indigo-kdl-parser \
     ros-indigo-common-msgs \

--- a/.dockers/ubuntu-14.04/Dockerfile.premade
+++ b/.dockers/ubuntu-14.04/Dockerfile.premade
@@ -4,5 +4,4 @@ ENV DEVEL_DIR /workspace
 
 RUN /auto-install-hpp.sh --branch ubuntu-14.04 --target \
                      "doxygen-1.8.10.install \
-                     osg-dae.install \
                      eigen3.install"

--- a/.dockers/ubuntu-16.04/Dockerfile
+++ b/.dockers/ubuntu-16.04/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update -qqy && apt-get install -qqy \
 
 RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
 RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-RUN echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub xenial robotpkg" > /etc/apt/sources.list.d/robotpkg.list
+RUN echo "deb [arch=amd64] http://robotpkg.openrobots.org/wip/packages/debian/pub xenial robotpkg" > /etc/apt/sources.list.d/robotpkg.list
+RUN echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub xenial robotpkg" >> /etc/apt/sources.list.d/robotpkg.list
 RUN curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | apt-key add -
 
 RUN apt-get update -qqy && apt-get install -qqy \
@@ -19,10 +20,12 @@ RUN apt-get update -qqy && apt-get install -qqy \
     libcdd-dev \
     libglpk-dev \
     liburdfdom-dev \
+    robotpkg-osg-dae \
     robotpkg-qpoases+doc \
     robotpkg-roboptim-core \
     robotpkg-roboptim-trajectory \
     robotpkg-romeo-description \
+    robotpkg-ros-baxter-common \
     ros-kinetic-xacro \
     ros-kinetic-kdl-parser \
     ros-kinetic-common-msgs \

--- a/.dockers/ubuntu-16.04/Dockerfile.premade
+++ b/.dockers/ubuntu-16.04/Dockerfile.premade
@@ -1,5 +1,3 @@
 FROM eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/ubuntu:16.04
 
 ENV DEVEL_HPP_DIR /workspace
-
-RUN /auto-install-hpp.sh --branch devel --target osg-dae.install

--- a/.dockers/ubuntu-18.04/Dockerfile
+++ b/.dockers/ubuntu-18.04/Dockerfile
@@ -1,0 +1,71 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qqy && apt-get install -qqy \
+   curl \
+   gnupg2 \
+   && rm -rf /var/lib/apt/lists/*
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN echo "deb [arch=amd64] http://robotpkg.openrobots.org/wip/packages/debian/pub bionic robotpkg" > /etc/apt/sources.list.d/robotpkg.list
+RUN echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub bionic robotpkg" >> /etc/apt/sources.list.d/robotpkg.list
+RUN curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | apt-key add -
+
+RUN apt-get update -qqy && apt-get install -qqy \
+    autoconf \
+    g++ \
+    cmake \
+    doxygen \
+    libassimp-dev \
+    libboost-dev \
+    libcdd-dev \
+    libglpk-dev \
+    liburdfdom-dev \
+    robotpkg-osg-dae \
+    robotpkg-qpoases+doc \
+    robotpkg-roboptim-core \
+    robotpkg-roboptim-trajectory \
+    robotpkg-romeo-description \
+    robotpkg-ros-baxter-common \
+    ros-melodic-xacro \
+    ros-melodic-kdl-parser \
+    ros-melodic-common-msgs \
+    ros-melodic-tf \
+    ros-melodic-tf-conversions \
+    libccd-dev \
+    ros-melodic-octomap \
+    ros-melodic-resource-retriever \
+    ros-melodic-srdfdom \
+    ros-melodic-pr2-description \
+    flex \
+    bison \
+    asciidoc \
+    source-highlight \
+    git \
+    libomniorb4-dev \
+    omniorb-nameserver \
+    omniidl \
+    omniidl-python \
+    libltdl-dev \
+    python-matplotlib \
+    libxml2-dev \
+    libtinyxml2-dev \
+    liblog4cxx-dev \
+    libltdl-dev \
+    qt4-dev-tools \
+    libqt4-opengl-dev \
+    libqtwebkit-dev \
+    libqtgui4 \
+    oxygen-icon-theme \
+    libopenscenegraph-dev \
+    openscenegraph \
+    libpcre3-dev \
+    sudo \
+    wget \
+ && apt-get remove -qqy texlive-latex-base texlive-binaries ghostscript \
+ && apt-get autoremove -qqy \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY auto-install-hpp.sh /

--- a/.dockers/ubuntu-18.04/Dockerfile.premade
+++ b/.dockers/ubuntu-18.04/Dockerfile.premade
@@ -1,0 +1,3 @@
+FROM eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/ubuntu:18.04
+
+ENV DEVEL_HPP_DIR /workspace

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,13 @@ devel-build:
       -  devel
     <<: *build_definition
 
+devel-18.04-build:
+    image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/devel-premade:18.04
+    allow_failure: true
+    only:
+      -  devel
+    <<: *build_definition
+
 master-test:
     image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/master-premade:16.04
     dependencies:
@@ -114,6 +121,15 @@ devel-test:
       -  devel
     <<: *test_definition
 
+devel-18.04-test:
+    image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/devel-premade:18.04
+    allow_failure: true
+    dependencies:
+      - devel-18.04-build
+    only:
+      -  devel
+    <<: *test_definition
+
 master-doc:
     image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/master-premade:16.04
     dependencies:
@@ -134,6 +150,15 @@ devel-doc:
     image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/devel-premade:16.04
     dependencies:
       - devel-build
+    only:
+      -  devel
+    <<: *doc_definition
+
+devel-18.04-doc:
+    image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/devel-premade:18.04
+    allow_failure: true
+    dependencies:
+      - devel-18.04-build
     only:
       -  devel
     <<: *doc_definition

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
 .build_template: &build_definition
     stage: build
     script:
+      - mkdir -p $DEVEL_HPP_DIR/src
       - export INSTALL_DOCUMENTATION=OFF
       - $CI_PROJECT_DIR/scripts/auto-install-hpp.sh --branch ${CI_COMMIT_REF_NAME} --gitrepo ${CI_PROJECT_URL}/raw --target test-ci
     after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ ubuntu-14.04-build:
       - ubuntu-14.04
     <<: *build_definition
 
-devel-build:
+devel-16.04-build:
     image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/devel-premade:16.04
     only:
       -  devel
@@ -113,10 +113,10 @@ ubuntu-14.04-test:
       - ubuntu-14.04
     <<: *test_definition
 
-devel-test:
+devel-16.04-test:
     image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/devel-premade:16.04
     dependencies:
-      - devel-build
+      - devel-16.04-build
     only:
       -  devel
     <<: *test_definition
@@ -146,10 +146,10 @@ ubuntu-14.04-doc:
       - ubuntu-14.04
     <<: *doc_definition
 
-devel-doc:
+devel-16.04-doc:
     image: eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/devel-premade:16.04
     dependencies:
-      - devel-build
+      - devel-16.04-build
     only:
       -  devel
     <<: *doc_definition

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -292,7 +292,7 @@ hpp-plot.configure.dep: hpp-corbaserver.install hpp-manipulation-corba.install \
 endif
 hpp-manipulation-urdf.configure.dep:hpp-manipulation.install \
 	hpp-manipulation-urdf.checkout
-hpp-corbaserver.configure.dep: hpp-core.install \
+hpp-corbaserver.configure.dep: hpp-core.install hpp-template-corba.install \
 	hpp-constraints.install hpp-corbaserver.checkout
 hpp-template-corba.configure.dep: hpp-util.install hpp-template-corba.checkout
 qgv.configure.dep: qgv.checkout

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -211,9 +211,9 @@ gepetto-viewer_repository=${GEPETTO_REPO}
 gepetto-viewer-corba_branch=devel
 gepetto-viewer-corba_repository=${GEPETTO_REPO}
 ifeq (${QT_VERSION}, 5)
-  gepetto-viewer-corba_extra_flags= -DUSE_QT4=OFF
+  gepetto-viewer_extra_flags= -DPROJECT_USE_QT4=OFF
 else
-  gepetto-viewer-corba_extra_flags= -DUSE_QT4=ON
+  gepetto-viewer_extra_flags= -DPROJECT_USE_QT4=ON
 endif
 
 pythonqt_branch=qt${QT_VERSION}
@@ -315,7 +315,7 @@ osg-dae.configure.dep: collada-dom.install \
 	osg-dae.checkout
 OpenSceneGraph-3.4.0.configure.dep: collada-dom.install \
 	OpenSceneGraph-3.4.0.checkout
-gepetto-viewer.configure.dep: gepetto-viewer.checkout
+gepetto-viewer.configure.dep: pythonqt.install gepetto-viewer.checkout
 gepetto-viewer-corba.configure.dep: gepetto-viewer.install \
 	pythonqt.install gepetto-viewer-corba.checkout
 hpp-gepetto-viewer.configure.dep: gepetto-viewer-corba.install \

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,7 +8,6 @@ LAAS_REPO=https://github.com/laas
 HPP_REPO=https://github.com/humanoid-path-planner
 SOT_REPO=https://github.com/stack-of-tasks
 GEPETTO_REPO=https://github.com/Gepetto
-RETHINK_ROBOTICS_REPO=https://github.com/RethinkRobotics
 TRAC_REPO=ssh://trac.laas.fr/git/jrl/robots/ros-hrp2
 
 SRC_DIR=${DEVEL_HPP_DIR}/src
@@ -149,17 +148,11 @@ universal_robot_repository=${HPP_REPO}
 hpp_universal_robot_branch=devel
 hpp_universal_robot_repository=${HPP_REPO}
 
-baxter_common_branch=master
-baxter_common_repository=${RETHINK_ROBOTICS_REPO}
-
 hpp-baxter_branch=master
 hpp-baxter_repository=${HPP_REPO}
 
 hpp_romeo_branch=master
 hpp_romeo_repository=${HPP_REPO}
-
-romeo_branch=master
-romeo_repository=${HPP_REPO}
 
 
 # }}}
@@ -243,14 +236,13 @@ all: hpp_tutorial.install hpp-gepetto-viewer.install
 	${MAKE} hpp-doc.install
 
 # For test on gepgitlab, install robot packages first
-test-ci: baxter_common.install romeo.install universal_robot.install \
-	hpp-environments.install
+test-ci: universal_robot.install  hpp-environments.install
 	${MAKE} hpp_tutorial.install hpp-gepetto-viewer.install hpp-rbprm-corba.install \
 	hpp_universal_robot.install && \
 	${MAKE} hpp-doc.install
 
 # For benchmark, install robot packages first
-benchmark: baxter_common.install romeo.install universal_robot.install \
+benchmark: universal_robot.install \
 	hpp-environments.install hrp2-14-description.install
 	${MAKE} hpp_tutorial.install hpp-gepetto-viewer.install; \
 	${MAKE} hpp-baxter.install hpp_romeo.install \
@@ -323,8 +315,7 @@ osg-dae.configure.dep: collada-dom.install \
 	osg-dae.checkout
 OpenSceneGraph-3.4.0.configure.dep: collada-dom.install \
 	OpenSceneGraph-3.4.0.checkout
-gepetto-viewer.configure.dep: ${OSG_PACKAGE}.install \
-	gepetto-viewer.checkout
+gepetto-viewer.configure.dep: gepetto-viewer.checkout
 gepetto-viewer-corba.configure.dep: gepetto-viewer.install \
 	pythonqt.install gepetto-viewer-corba.checkout
 hpp-gepetto-viewer.configure.dep: gepetto-viewer-corba.install \
@@ -335,10 +326,8 @@ universal_robot.configure.dep: universal_robot.checkout
 hpp_universal_robot.configure.dep: universal_robot.install \
 	hpp_universal_robot.checkout
 hpp-environments.configure.dep: hpp-environments.checkout
-baxter_common.configure.dep: baxter_common.checkout
-hpp-baxter.configure.dep: baxter_common.install hpp-baxter.checkout
-hpp_romeo.configure.dep: romeo.install hpp_romeo.checkout
-romeo.configure.dep: romeo.checkout
+hpp-baxter.configure.dep: hpp-baxter.checkout
+hpp_romeo.configure.dep: hpp_romeo.checkout
 hpp-affordance.configure.dep: hpp-core.install hpp-fcl.install hpp-affordance.checkout
 hpp-affordance-corba.configure.dep: hpp-affordance.install hpp-template-corba.install \
  hpp-corbaserver.install hpp-affordance-corba.checkout
@@ -474,36 +463,6 @@ universal_robot.install_nodep:universal_robot.configure_nodep
 universal_robot.install:universal_robot.configure
 	cd ${SRC_DIR}/$(@:.install=)/ur_description/${BUILD_FOLDER};\
 	make install
-
-baxter_common.configure_nodep:
-	mkdir -p ${SRC_DIR}/$(@:.configure_nodep=)/baxter_description/${BUILD_FOLDER}; \
-	cd ${SRC_DIR}/$(@:.configure_nodep=)/baxter_description/${BUILD_FOLDER}; \
-	cmake -DCMAKE_INSTALL_PREFIX=${DEVEL_HPP_DIR}/install -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -DNDEBUG" ${$(@:.configure_nodep=)_extra_flags} ..; \
-	mkdir -p ${SRC_DIR}/$(@:.configure_nodep=)/rethink_ee_description/${BUILD_FOLDER}; \
-	cd ${SRC_DIR}/$(@:.configure_nodep=)/rethink_ee_description/${BUILD_FOLDER}; \
-	cmake -DCMAKE_INSTALL_PREFIX=${DEVEL_HPP_DIR}/install -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-g -O3 -DNDEBUG" ${$(@:.configure_nodep=)_extra_flags} ..
-
-baxter_common.install_nodep:baxter_common.configure_nodep
-	cd ${SRC_DIR}/$(@:.install_nodep=)/baxter_description/${BUILD_FOLDER};\
-	make install; \
-	cd ${SRC_DIR}/$(@:.install_nodep=)/rethink_ee_description/${BUILD_FOLDER};\
-	make install
-
-baxter_common.install:baxter_common.configure
-	cd ${SRC_DIR}/$(@:.install=)/baxter_description/${BUILD_FOLDER};\
-	make install; \
-	cd ${SRC_DIR}/$(@:.install=)/rethink_ee_description/${BUILD_FOLDER};\
-	make install
-
-romeo.configure: romeo.configure.dep
-	. ${INSTALL_HPP_DIR}/setup.sh; \
-	cd ${SRC_DIR}/romeo/romeo_description;\
-	mkdir -p ${BUILD_FOLDER}; \
-	cd ${SRC_DIR}/romeo/romeo_description/${BUILD_FOLDER}; \
-	cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_HPP_DIR} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
-
-romeo.install: romeo.configure
-	${MAKE} -C ${SRC_DIR}/romeo/romeo_description/${BUILD_FOLDER} install
 
 # }}}
 

--- a/doc/config/ubuntu-16.04-kinetic.sh
+++ b/doc/config/ubuntu-16.04-kinetic.sh
@@ -1,22 +1,24 @@
 export INSTALL_HPP_DIR=$DEVEL_HPP_DIR/install
+export ROBOTPKG=/opt/openrobots
+export ROS=/opt/ros/kinetic
 
-export PATH=$INSTALL_HPP_DIR/sbin:$INSTALL_HPP_DIR/bin:/opt/ros/kinetic/bin:$PATH
-export PKG_CONFIG_PATH=$INSTALL_HPP_DIR/lib/pkgconfig/:/opt/ros/kinetic/lib/pkgconfig:/opt/openrobots/lib/pkgconfig
+export PATH=$INSTALL_HPP_DIR/sbin:$INSTALL_HPP_DIR/bin:$ROS/bin:$PATH
+export PKG_CONFIG_PATH=$INSTALL_HPP_DIR/lib/pkgconfig/:$ROS/lib/pkgconfig:$ROBOTPKG/lib/pkgconfig
 
-export PYTHONPATH=$INSTALL_HPP_DIR/lib/python2.7/site-packages:$INSTALL_HPP_DIR/lib/python2.7/dist-packages:/opt/ros/kinetic/lib/python2.7/dist-packages:$PYTHONPATH
+export PYTHONPATH=$INSTALL_HPP_DIR/lib/python2.7/site-packages:$INSTALL_HPP_DIR/lib/python2.7/dist-packages:$ROS/lib/python2.7/dist-packages:$PYTHONPATH
 
-export LD_LIBRARY_PATH=$INSTALL_HPP_DIR/lib:$INSTALL_HPP_DIR/lib64:/opt/ros/kinetic/lib:/opt/openrobots/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$INSTALL_HPP_DIR/lib:$INSTALL_HPP_DIR/lib64:$ROS/lib:$ROBOTPKG/lib:$LD_LIBRARY_PATH
 
 if [ -f $INSTALL_HPP_DIR/setup.bash ]; then
     source $INSTALL_HPP_DIR/setup.bash
 else
-    source /opt/ros/kinetic/setup.bash
+    source $ROS/setup.bash
 fi
 # Make sure that /opt/ros/kinetic/setup.bash is in the ROS_PACKAGE_PATH,
 # otherwise, you should add it by hand in the line below.
-export ROS_PACKAGE_PATH=$INSTALL_HPP_DIR/share:$ROS_PACKAGE_PATH
+export ROS_PACKAGE_PATH=$INSTALL_HPP_DIR/share:$ROBOTPKG/share:$ROS_PACKAGE_PATH
 
 if [ -f "${INSTALL_HPP_DIR}/etc/hpp-tools/bashrc" ]; then
     source "${INSTALL_HPP_DIR}/etc/hpp-tools/bashrc"
 fi
-export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/opt/openrobots
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$ROBOTPKG

--- a/doc/config/ubuntu-18.04-melodic.sh
+++ b/doc/config/ubuntu-18.04-melodic.sh
@@ -1,0 +1,24 @@
+export INSTALL_HPP_DIR=$DEVEL_HPP_DIR/install
+export ROBOTPKG=/opt/openrobots
+export ROS=/opt/ros/melodic
+
+export PATH=$INSTALL_HPP_DIR/sbin:$INSTALL_HPP_DIR/bin:$ROS/bin:$PATH
+export PKG_CONFIG_PATH=$INSTALL_HPP_DIR/lib/pkgconfig/:$ROS/lib/pkgconfig:$ROBOTPKG/lib/pkgconfig
+
+export PYTHONPATH=$INSTALL_HPP_DIR/lib/python2.7/site-packages:$INSTALL_HPP_DIR/lib/python2.7/dist-packages:$ROS/lib/python2.7/dist-packages:$PYTHONPATH
+
+export LD_LIBRARY_PATH=$INSTALL_HPP_DIR/lib:$INSTALL_HPP_DIR/lib64:$ROS/lib:$ROBOTPKG/lib:$LD_LIBRARY_PATH
+
+if [ -f $INSTALL_HPP_DIR/setup.bash ]; then
+    source $INSTALL_HPP_DIR/setup.bash
+else
+    source $ROS/setup.bash
+fi
+# Make sure that /opt/ros/melodic/setup.bash is in the ROS_PACKAGE_PATH,
+# otherwise, you should add it by hand in the line below.
+export ROS_PACKAGE_PATH=$INSTALL_HPP_DIR/share:$ROBOTPKG/share:$ROS_PACKAGE_PATH
+
+if [ -f "${INSTALL_HPP_DIR}/etc/hpp-tools/bashrc" ]; then
+    source "${INSTALL_HPP_DIR}/etc/hpp-tools/bashrc"
+fi
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$ROBOTPKG

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,7 +27,7 @@ You will find three files in the directory `${DEVEL_HPP_DIR}/tarball/`:
 
 ```
 branch=$(git branch --no-color | grep \* | cut -d' ' -f2)
-for ubuntu in 14.04 16.04
+for ubuntu in 14.04 16.04 18.04
 do
     docker build -t eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/ubuntu:${ubuntu} -f .dockers/ubuntu-${ubuntu}/Dockerfile ./scripts
     docker build -t eur0c.laas.fr:5000/humanoid-path-planner/hpp-doc/${branch}-premade:${ubuntu} -f .dockers/ubuntu-${ubuntu}/Dockerfile.premade ./scripts

--- a/scripts/auto-install-hpp.sh
+++ b/scripts/auto-install-hpp.sh
@@ -28,6 +28,18 @@ case $HOST_DIST in
     APT_BUILD_DEP=""
     CONFIG_FILE="ubuntu-16.04-kinetic.sh"
     ;;
+  bionic)
+    APT_DEP="g++ cmake doxygen libboost-dev liburdfdom-dev \
+      libassimp-dev ros-melodic-xacro ros-melodic-kdl-parser ros-melodic-common-msgs \
+      ros-melodic-tf ros-melodic-tf-conversions libccd-dev ros-melodic-octomap \
+      ros-melodic-resource-retriever ros-melodic-srdfdom ros-melodic-pr2-description flex \
+      bison asciidoc source-highlight git libomniorb4-dev omniorb-nameserver omniidl \
+      omniidl-python libltdl-dev python-matplotlib libxml2-dev libtinyxml2-dev \
+      liblog4cxx-dev libltdl-dev qt4-dev-tools libqt4-opengl-dev libqtgui4 libqtwebkit-dev oxygen-icon-theme \
+      libopenscenegraph-dev openscenegraph libpcre3-dev libcdd-dev libglpk-dev"
+    APT_BUILD_DEP=""
+    CONFIG_FILE="ubuntu-18.04-melodic.sh"
+    ;;
   *)
     echo "Unknow host distribution."
     exit 1
@@ -90,7 +102,7 @@ do
         echo "$v=${!v}"
       done
       read -p "Continue (y/N)?" choice
-      case "$choice" in 
+      case "$choice" in
         y|Y )
           echo "yes"
           ;;


### PR DESCRIPTION
Hi,

This PR:
- use robotpkg binaries for osg-dae, baxter-common & romeo-description
- fixes the `ROS_PACKAGE_PATH` to do so in `config.sh`
- updates some changes in devel branches, like
    - gepetto-viewer needs the `PROJECT_USE_QT4` flag
    - gepetto-viewer-corba don't need it anymore, and uses the one from gepetto-viewer
    - hpp-corbaserver needs hpp-template-corba
- adds 18.04 support with:
    - a `Dockerfile` and a `Dockerfile.premade`
    - new jobs (allowed to fail for now) in the `.gitlab-ci.yml`
    - a `config.sh`
    - a case switch in `auto-install-hpp.sh`
- while here, update the cmake submodule

Everything (with the only exception of https://github.com/humanoid-path-planner/hpp-rbprm/issues/31 ) looks good on 16.04.
On 18.04, I already corrected a few minor things, but more work is still required here and there.