### PR TITLE
Merge devel and stable branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ variables:
       - $DEVEL_HPP_DIR/test.sh hpp-manipulation-urdf       || status=1
       - $DEVEL_HPP_DIR/test.sh hpp-manipulation-corba      || status=1
       - $DEVEL_HPP_DIR/test.sh hpp-rbprm                   || status=1
-      - $DEVEL_HPP_DIR/test.sh hpp-rbprm-corba             || status=1
+      #- $DEVEL_HPP_DIR/test.sh hpp-rbprm-corba             || status=1
       - set -e
       - exit $status
     allow_failure: true

--- a/instructions/stable-binary.md
+++ b/instructions/stable-binary.md
@@ -1,3 +1,61 @@
+## Binary installation on ubuntu-20.04 64 bit with ros-noetic
+
+To install all the packages on ubuntu 20.04 LTS 64 bit, you should do the following steps:
+
+  1. install ROS-noetic: follow steps 1.1 to 1.3 of [the ROS installation website.](http://wiki.ros.org/noetic/Installation/Ubuntu).
+
+  2. install robotpkg: follow [the robotpkg installation website](http://robotpkg.openrobots.org/debian.html).
+
+  3. install HPP:
+
+    ```bash
+    pyver=38
+    sudo apt-get install robotpkg-py${pyver}-hpp-manipulation-corba robotpkg-py${pyver}-qt5-hpp-gepetto-viewer
+    ```
+
+  4. install (optionnal) extra packages for demonstrations:
+
+    - Tutorials:
+
+      ```bash
+      sudo apt-get install robotpkg-py${pyver}-hpp-tutorial
+      ```
+
+    - GUI:
+
+      ```bash
+      sudo apt-get install robotpkg-py${pyver}-qt5-hpp-gui robotpkg-py${pyver}-qt5-hpp-plot
+      ```
+
+    - Some robot descriptions:
+
+      ```bash
+      sudo apt-get install ros-noetic-pr2-description robotpkg-py${pyver}-hpp-environments robotpkg-romeo-description
+      ```
+
+    - documentation:
+
+      ```bash
+      sudo apt-get install robotpkg-hpp-doc
+      ```
+
+  5. setup your environment variables by adding the following lines (fix Python version if necessary) to your `.bashrc`:
+
+    ```bash
+    source /opt/ros/noetic/setup.bash
+
+    export PATH=/opt/openrobots/bin${!PATH:-:}${PATH}
+    export LD_LIBRARY_PATH=/opt/openrobots/lib${!LD_LIBRARY_PATH:-:}${LD_LIBRARY_PATH}
+    export PYTHONPATH=/opt/openrobots/lib/python2.7/site-packages${!PYTHONPATH:-:}${PYTHONPATH}
+    export ROS_PACKAGE_PATH=/opt/openrobots/share${!ROS_PACKAGE_PATH:-:}${ROS_PACKAGE_PATH}
+
+    export CMAKE_PREFIX_PATH=/opt/openrobots${!CMAKE_PREFIX_PATH:-:}${CMAKE_PREFIX_PATH}
+    export PKG_CONFIG_PATH=/opt/openrobots${!PKG_CONFIG_PATH:-:}${PKG_CONFIG_PATH}
+    ```
+
+  6. open `/opt/openrobots/share/doc/hpp-doc/index.html` in a web brower and you
+  will have access to the documentation of most packages.
+
 ## Binary installation on ubuntu-18.04 64 bit with ros-melodic
 
 To install all the packages on ubuntu 18.04 LTS 64 bit, you should do the following steps:
@@ -32,6 +90,12 @@ To install all the packages on ubuntu 18.04 LTS 64 bit, you should do the follow
 
       ```bash
       sudo apt-get install ros-melodic-pr2-description robotpkg-py${pyver}-hpp-environments robotpkg-romeo-description
+      ```
+
+    - documentation:
+
+      ```bash
+      sudo apt-get install robotpkg-hpp-doc
       ```
 
   5. setup your environment variables by adding the following lines (fix Python version if necessary) to your `.bashrc`:

--- a/makefiles/devel.mk
+++ b/makefiles/devel.mk
@@ -35,12 +35,12 @@ INSTALL_DOCUMENTATION=ON
 
 # Either a version tag (e.g. v4.3.0), stable or devel
 HPP_VERSION=devel
-HPP_EXTRA_FLAGS= -DBUILD_TESTING=${BUILD_TESTING}$
+HPP_EXTRA_FLAGS= -DBUILD_TESTING=${BUILD_TESTING}
 
 ##################################
 # {{{ Dependencies
 
-pinocchio_branch=v2.6.3
+pinocchio_branch=v2.6.7
 pinocchio_repository=${SOT_REPO}
 pinocchio_extra_flags= -DBUILD_UNIT_TESTS=OFF -DBUILD_WITH_COLLISION_SUPPORT=ON
 
@@ -100,18 +100,21 @@ hpp-plot_repository=${HPP_REPO}
 hpp-gui_branch=${HPP_VERSION}
 hpp-gui_repository=${HPP_REPO}
 
+hpp-practicals_branch=${HPP_VERSION}
+hpp-practicals_repository=${HPP_REPO}
+
 # }}}
 ##################################
 # {{{ Robot specific package + test packages
 
-example-robot-data_branch=devel
+example-robot-data_branch=${HPP_VERSION}
 example-robot-data_repository=${GEPETTO_REPO}
 example-robot-data_extra_flags= -DBUILD_PYTHON_INTERFACE=OFF
 
 hrp2-14-description_branch=master
 hrp2-14-description_repository=${TRAC_REPO}
 
-hpp-hrp2_branch=devel
+hpp-hrp2_branch=${HPP_VERSION}
 hpp-hrp2_repository=${HPP_REPO}
 
 robot_capsule_urdf_branch=groovy

--- a/makefiles/devel.mk
+++ b/makefiles/devel.mk
@@ -8,7 +8,6 @@ LAAS_REPO=https://github.com/laas
 HPP_REPO=https://github.com/humanoid-path-planner
 SOT_REPO=https://github.com/stack-of-tasks
 GEPETTO_REPO=https://github.com/Gepetto
-TRAC_REPO=ssh://trac.laas.fr/git/jrl/robots/ros-hrp2
 LOCO3D_REPO=https://github.com/loco-3d
 
 SRC_DIR=${DEVEL_HPP_DIR}/src
@@ -110,12 +109,6 @@ hpp-practicals_repository=${HPP_REPO}
 example-robot-data_branch=${HPP_VERSION}
 example-robot-data_repository=${GEPETTO_REPO}
 example-robot-data_extra_flags= -DBUILD_PYTHON_INTERFACE=OFF
-
-hrp2-14-description_branch=master
-hrp2-14-description_repository=${TRAC_REPO}
-
-hpp-hrp2_branch=${HPP_VERSION}
-hpp-hrp2_repository=${HPP_REPO}
 
 robot_capsule_urdf_branch=groovy
 robot_capsule_urdf_repository=${LAAS_REPO}
@@ -230,8 +223,7 @@ test-ci: example-robot-data.install  hpp-environments.install \
 	${MAKE} hpp-doc.install
 
 # For benchmark, install robot packages first
-benchmark: example-robot-data.install \
-	hpp-environments.install hrp2-14-description.install
+benchmark: example-robot-data.install hpp-environments.install
 	${MAKE} hpp_tutorial.install hpp-gepetto-viewer.install; \
 	${MAKE} hpp-baxter.install hpp_romeo.install \
 	hpp-universal-robot.install hpp-plot.install hpp-gui.install; \
@@ -274,12 +266,6 @@ qgv.configure.dep: qgv.checkout
 robot_model_py.configure.dep: robot_model_py.checkout
 robot_capsule_urdf.configure.dep: robot_model_py.install \
 	robot_capsule_urdf.checkout
-hpp-hrp2.configure.dep: hrp2-14-description.install hpp-corbaserver.install \
-	hpp-hrp2.checkout
-hrp2-14-description.configure.dep: robot_capsule_urdf.install \
-	robot_model_py.install hrp2-14-description.checkout
-test-hpp.configure.dep: \
-	hpp-gepetto-viewer.install hpp-hrp2.install test-hpp.checkout
 hpp_tutorial.configure.dep: hpp-gepetto-viewer.install \
 	hpp-manipulation-corba.install hpp_tutorial.checkout
 hpp_benchmark.configure.dep: hpp_tutorial.install hpp_benchmark.checkout

--- a/makefiles/stable.mk
+++ b/makefiles/stable.mk
@@ -35,7 +35,7 @@ INSTALL_DOCUMENTATION=ON
 
 # Either a version tag (e.g. v4.3.0), stable or devel
 HPP_VERSION=v4.13.0
-HPP_EXTRA_FLAGS= -DBUILD_TESTING=${BUILD_TESTING}$
+HPP_EXTRA_FLAGS= -DBUILD_TESTING=${BUILD_TESTING}
 
 ##################################
 # {{{ Dependencies
@@ -50,6 +50,7 @@ hpp-template-corba_repository=${HPP_REPO}
 # }}}
 ##################################
 # {{{ Packages supporting HPP_VERSION
+#
 hpp-util_branch=${HPP_VERSION}
 hpp-util_repository=${HPP_REPO}
 
@@ -210,7 +211,7 @@ else
 	qgv_extra_flags=-DBINDINGS_QT5=OFF -DBINDINGS_QT4=ON
 endif
 
-hpp-tools_branch=v4.9.0
+hpp-tools_branch=master
 hpp-tools_repository=${HPP_REPO}
 hpp-tools_extra_flags=
 

--- a/makefiles/stable.mk
+++ b/makefiles/stable.mk
@@ -8,7 +8,6 @@ LAAS_REPO=https://github.com/laas
 HPP_REPO=https://github.com/humanoid-path-planner
 SOT_REPO=https://github.com/stack-of-tasks
 GEPETTO_REPO=https://github.com/Gepetto
-TRAC_REPO=ssh://trac.laas.fr/git/jrl/robots/ros-hrp2
 LOCO3D_REPO=https://github.com/loco-3d
 
 SRC_DIR=${DEVEL_HPP_DIR}/src
@@ -110,12 +109,6 @@ hpp-practicals_repository=${HPP_REPO}
 example-robot-data_branch=v4.0.1
 example-robot-data_repository=${GEPETTO_REPO}
 example-robot-data_extra_flags= -DBUILD_PYTHON_INTERFACE=OFF
-
-hrp2-14-description_branch=master
-hrp2-14-description_repository=${TRAC_REPO}
-
-hpp-hrp2_branch=v4.9.0
-hpp-hrp2_repository=${HPP_REPO}
 
 robot_capsule_urdf_branch=groovy
 robot_capsule_urdf_repository=${LAAS_REPO}
@@ -230,8 +223,7 @@ test-ci: example-robot-data.install  hpp-environments.install \
 	${MAKE} hpp-doc.install
 
 # For benchmark, install robot packages first
-benchmark: example-robot-data.install \
-	hpp-environments.install hrp2-14-description.install
+benchmark: example-robot-data.install hpp-environments.install
 	${MAKE} hpp_tutorial.install hpp-gepetto-viewer.install; \
 	${MAKE} hpp-baxter.install hpp_romeo.install \
 	hpp-universal-robot.install hpp-plot.install hpp-gui.install; \
@@ -274,12 +266,6 @@ qgv.configure.dep: qgv.checkout
 robot_model_py.configure.dep: robot_model_py.checkout
 robot_capsule_urdf.configure.dep: robot_model_py.install \
 	robot_capsule_urdf.checkout
-hpp-hrp2.configure.dep: hrp2-14-description.install hpp-corbaserver.install \
-	hpp-hrp2.checkout
-hrp2-14-description.configure.dep: robot_capsule_urdf.install \
-	robot_model_py.install hrp2-14-description.checkout
-test-hpp.configure.dep: \
-	hpp-gepetto-viewer.install hpp-hrp2.install test-hpp.checkout
 hpp_tutorial.configure.dep: hpp-gepetto-viewer.install \
 	hpp-manipulation-corba.install hpp_tutorial.checkout
 hpp_benchmark.configure.dep: hpp_tutorial.install hpp_benchmark.checkout


### PR DESCRIPTION
Update installation instruction: add binary installation for Ubuntu-20.04
Remove reference to HRP2.

Once merged, it would be helpful to move branch stable to commit d53a61a so that the new installation instructions appear on the website.