### PR TITLE
Modify installation entry for Conda now that remaining package have been added to conda

### DIFF
--- a/instructions/conda-packages.md
+++ b/instructions/conda-packages.md
@@ -3,7 +3,7 @@
 ### Installation
 To install all the packages on any Linux or Osx distribution
 
-  1. Install miniconda [the miniconda installation website.](https://docs.conda.io/en/latest/miniconda.html).
+  1. Install miniconda through [the miniconda installation website.](https://docs.conda.io/en/latest/miniconda.html).
 
   2. Create an environment with your choice of python version (from `3.8` to `3.11`).
 
@@ -16,7 +16,7 @@ It will install all hpp packages and gepetto viewer with python bindings.
 ### Usage
 Remember to use `conda activate hpp` in every terminal where you run `hppcorbaserver`, `hpp-manipulation-server`, `gepetto-gui` or any Python script that uses hpp.
 
-To access the documentation, open a terminal activate the environment and open the file `$CONDA_PREFIX/share/doc/hpp-doc/index.html` with the brower of your choice:
+To access the documentation, open a terminal activate the environment, and open the file `$CONDA_PREFIX/share/doc/hpp-doc/index.html` with the browser of your choice:
 
 ```bash
 conda activate hpp

--- a/instructions/conda-packages.md
+++ b/instructions/conda-packages.md
@@ -7,9 +7,11 @@ To install all the packages on any linux or osx distribution
   2. Create an environment with your choice of python version (from `3.8` to `3.11`).
 
     ```bash
-    conda create -n hpp -c conda-forge python=3.8 hpp-gepetto-viewer -y
+    conda create -n hpp -c conda-forge python=3.8 hpp-doc -y
     ```
 
 It will install all hpp packages and gepetto viewer with python bindings.
 
 Remember to use `conda activate hpp` in every terminal where you run `hppcorbaserver`, `hpp-manipulation-server`, `gepetto-gui` or any python script that use hpp.
+
+# TODO: access Doc online

--- a/instructions/conda-packages.md
+++ b/instructions/conda-packages.md
@@ -7,9 +7,9 @@ To install all the packages on any Linux or Osx distribution
 
   3. Create an environment with your choice of python version (from `3.8` to `3.11`).
 
-    ```bash
-    conda create -n hpp -c conda-forge python=3.11 hpp-doc -y
-    ```
+```bash
+conda create -n hpp -c conda-forge python=3.11 hpp-doc -y
+```
 
 It will install all hpp packages and gepetto viewer with python bindings.
 
@@ -17,6 +17,7 @@ It will install all hpp packages and gepetto viewer with python bindings.
 Remember to use `conda activate hpp` in every terminal where you run `hppcorbaserver`, `hpp-manipulation-server`, `gepetto-gui` or any Python script that uses hpp.
 
 To access the documentation, open a terminal activate the environment and open the file `$CONDA_PREFIX/share/doc/hpp-doc/index.html` with the brower of your choice:
+
 ```bash
 conda activate hpp
 firefox $CONDA_PREFIX/share/doc/hpp-doc/index.html

--- a/instructions/conda-packages.md
+++ b/instructions/conda-packages.md
@@ -5,7 +5,7 @@ To install all the packages on any Linux or Osx distribution
 
   1. Install miniconda [the miniconda installation website.](https://docs.conda.io/en/latest/miniconda.html).
 
-  3. Create an environment with your choice of python version (from `3.8` to `3.11`).
+  2. Create an environment with your choice of python version (from `3.8` to `3.11`).
 
 ```bash
 conda create -n hpp -c conda-forge python=3.11 hpp-doc -y

--- a/instructions/conda-packages.md
+++ b/instructions/conda-packages.md
@@ -1,6 +1,6 @@
-## Source installation on every linux or osx
+## Source installation on every Linux or Osx
 
-To install all the packages on any linux or osx distribution
+To install all the packages on any Linux or Osx distribution
 
   1. Install miniconda [the miniconda installation website.](https://docs.conda.io/en/latest/miniconda.html).
 
@@ -12,6 +12,6 @@ To install all the packages on any linux or osx distribution
 
 It will install all hpp packages and gepetto viewer with python bindings.
 
-Remember to use `conda activate hpp` in every terminal where you run `hppcorbaserver`, `hpp-manipulation-server`, `gepetto-gui` or any python script that use hpp.
+Remember to use `conda activate hpp` in every terminal where you run `hppcorbaserver`, `hpp-manipulation-server`, `gepetto-gui` or any Python script that uses hpp.
 
-# TODO: access Doc online
+To access the documentation, open:  `firefox $CONDA_PREFIX/share/doc/hpp-doc/index.html` in a web browser and you will have access to the documentation of most packages.

--- a/instructions/conda-packages.md
+++ b/instructions/conda-packages.md
@@ -1,17 +1,23 @@
 ## Source installation on every Linux or Osx
 
+### Installation
 To install all the packages on any Linux or Osx distribution
 
   1. Install miniconda [the miniconda installation website.](https://docs.conda.io/en/latest/miniconda.html).
 
-  2. Create an environment with your choice of python version (from `3.8` to `3.11`).
+  3. Create an environment with your choice of python version (from `3.8` to `3.11`).
 
     ```bash
-    conda create -n hpp -c conda-forge python=3.8 hpp-doc -y
+    conda create -n hpp -c conda-forge python=3.11 hpp-doc -y
     ```
 
 It will install all hpp packages and gepetto viewer with python bindings.
 
+### Usage
 Remember to use `conda activate hpp` in every terminal where you run `hppcorbaserver`, `hpp-manipulation-server`, `gepetto-gui` or any Python script that uses hpp.
 
-To access the documentation, open:  `firefox $CONDA_PREFIX/share/doc/hpp-doc/index.html` in a web browser and you will have access to the documentation of most packages.
+To access the documentation, open a terminal activate the environment and open the file `$CONDA_PREFIX/share/doc/hpp-doc/index.html` with the brower of your choice:
+```bash
+conda activate hpp
+firefox $CONDA_PREFIX/share/doc/hpp-doc/index.html
+```


### PR DESCRIPTION
Following my visit at last end of septembre, I added (hpp-plot, hpp-tutorial, hpp-practical, qgv and hpp-doc) to conda  and consolidate the existing package using new conda-forge guidelines.

This new command install the whole stack HPP and explain how to access the doc.