### PR TITLE
Try to fix broken video links

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,3 +1,10 @@
+- name: construction-set
+  id: 3
+  title: Manipulation planning for assembling objects
+  description: "Complex assembly problems can be defined and solved."
+  video:
+    youtube_id: ZVvePCl6qP0
+
 - name: fiad-showcase
   id: 2
   title: Factory In A Day - Full sequence
@@ -5,26 +12,19 @@
   video:
     url: http://projects.laas.fr/gepetto/uploads/Members/fiad-full-sequence.mp4
 
-- name: manipulation_baxter
-  id: 3
-  title: Manipulation planning
-  description: "A sequence of tasks is automatically discovered during the planning in order to swap the position of the boxes."
-  video:
-    url: https://peertube.laas.fr/download/videos/ae261aee-10f4-4ee3-9e40-45842957b7bc-540.mp4
-
 - name: manipulation_romeo_placard
   id: 10
   title: Manipulation planning
   description: "Romeo rotates a placard. Each hand can grasp the placard with one degree of freedom in rotation, thus the space of valid grasps for each hand is continuous. This case illustrates the <em>crossing foliation issue</em>."
   video:
-    url: https://peertube.laas.fr/download/videos/8854092f-d4ac-4d7b-b69a-345c24e1eadd-1080.mp4
+    url: https://peertube.laas.fr/videos/embed/8854092f-d4ac-4d7b-b69a-345c24e1eadd
 
 - name: multicontact_hrp2_standup
   id: 4
   title: Multi-contact locomotion - Stand up
   description: "A sequence of contact configurations for a multiped robot is computed. Position constraint and static equilibrium constraint are used to create and maintain contacts along the sequence."
   video:
-    url: https://peertube.laas.fr/download/videos/4baf0998-611e-45e6-a5ad-5b74a112a500-1080.mp4
+    url: https://peertube.laas.fr/videos/embed/4baf0998-611e-45e6-a5ad-5b74a112a500
 
 #- name: multicontact_hrp2_stairs
 #id: 5
@@ -40,14 +40,14 @@
   title: Constraint based path optimization
   description: "Path optimization algorithm based on collision constraints, automatically built between bodies close to collision."
   video:
-    url: https://peertube.laas.fr/download/videos/a0c0715b-d9c5-445f-acae-513fe61859a5-1080.mp4
+    url: https://peertube.laas.fr/videos/embed/a0c0715b-d9c5-445f-acae-513fe61859a5
 
 - name: rod_planning
   id: 7
   title: Elastic rod planning.
   description: "Integration of external software: QSERL and XDE are used to implement a dedicated steering method for elastic rod planning.<br/><em>Engine model courtesy of Siemens-KineoCAM.</em>"
   video:
-    url: https://peertube.laas.fr/download/videos/742a40eb-de0b-46c1-b4a1-461196da65e9-1080.mp4
+    url: https://peertube.laas.fr/videos/embed/742a40eb-de0b-46c1-b4a1-461196da65e9
 
 - name: manipulation_pr2_drawer
   id: 8
@@ -61,7 +61,7 @@
   title: Locomotion planning expressed as a manipulation planning problem
   description: "The locomotion planning problem is expressed as a Manipulation planning problem."
   video:
-    url: https://peertube.laas.fr/download/videos/d6022f88-c8c0-40e6-9bde-036cb3f7bef4-960.mp4
+    url: https://peertube.laas.fr/videos/embed/d6022f88-c8c0-40e6-9bde-036cb3f7bef4
 
 - name: hpp-showcase
   id: 0
@@ -75,7 +75,7 @@
   title: HPP manipulation stack demonstration
   description: "Differents features that can be achieved using the manipulation stack of the Humanoid Path Planner"
   video:
-    url: https://peertube.laas.fr/download/videos/fd152247-51d3-4605-973a-8208fed090fc-1080.mp4
+    url: https://peertube.laas.fr/videos/embed/fd152247-51d3-4605-973a-8208fed090fc
 
 #### Examples of format to use. Remember : 1 image or 1 video. not both
 # - name: pg-ellipses

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -12,20 +12,6 @@
   video:
     url: http://projects.laas.fr/gepetto/uploads/Members/fiad-full-sequence.mp4
 
-- name: manipulation_romeo_placard
-  id: 10
-  title: Manipulation planning
-  description: "Romeo rotates a placard. Each hand can grasp the placard with one degree of freedom in rotation, thus the space of valid grasps for each hand is continuous. This case illustrates the <em>crossing foliation issue</em>."
-  video:
-    url: https://peertube.laas.fr/videos/embed/8854092f-d4ac-4d7b-b69a-345c24e1eadd
-
-- name: multicontact_hrp2_standup
-  id: 4
-  title: Multi-contact locomotion - Stand up
-  description: "A sequence of contact configurations for a multiped robot is computed. Position constraint and static equilibrium constraint are used to create and maintain contacts along the sequence."
-  video:
-    url: https://peertube.laas.fr/videos/embed/4baf0998-611e-45e6-a5ad-5b74a112a500
-
 #- name: multicontact_hrp2_stairs
 #id: 5
 #title: Multi-contact locomotion - Stairs
@@ -35,20 +21,6 @@
 #youtube_id: 01K_nmax9E0
 #youtube_extra: start=2m07&end=2m55
 
-- name: optimization
-  id: 6
-  title: Constraint based path optimization
-  description: "Path optimization algorithm based on collision constraints, automatically built between bodies close to collision."
-  video:
-    url: https://peertube.laas.fr/videos/embed/a0c0715b-d9c5-445f-acae-513fe61859a5
-
-- name: rod_planning
-  id: 7
-  title: Elastic rod planning.
-  description: "Integration of external software: QSERL and XDE are used to implement a dedicated steering method for elastic rod planning.<br/><em>Engine model courtesy of Siemens-KineoCAM.</em>"
-  video:
-    url: https://peertube.laas.fr/videos/embed/742a40eb-de0b-46c1-b4a1-461196da65e9
-
 - name: manipulation_pr2_drawer
   id: 8
   title: Manipulation planning with tool use inference
@@ -56,26 +28,12 @@
   video:
     youtube_id: iRJtmt7RzDM
 
-- name: manipulation_hrp2_stairs
-  id: 9
-  title: Locomotion planning expressed as a manipulation planning problem
-  description: "The locomotion planning problem is expressed as a Manipulation planning problem."
-  video:
-    url: https://peertube.laas.fr/videos/embed/d6022f88-c8c0-40e6-9bde-036cb3f7bef4
-
 - name: hpp-showcase
   id: 0
   title: HPP demonstration
   description: "Differents features that can be achieved using the Humanoid Path Planner"
   video:
     youtube_id: 01K_nmax9E0
-
-- name: hpp-manipulation-showcase
-  id: 1
-  title: HPP manipulation stack demonstration
-  description: "Differents features that can be achieved using the manipulation stack of the Humanoid Path Planner"
-  video:
-    url: https://peertube.laas.fr/videos/embed/fd152247-51d3-4605-973a-8208fed090fc
 
 #### Examples of format to use. Remember : 1 image or 1 video. not both
 # - name: pg-ellipses

--- a/index.html
+++ b/index.html
@@ -9,30 +9,22 @@ layout: home
     <div class="col-md-5 text-center">
       <div class="row">
         <div class="col-md-6" style="padding-top:0.5em; padding-bottom:0.5em;">
-          <a href="http://projetromeo.com">
             <img title="Projet ROMEO 2" id="projetromeo_logo" src="{{ site.baseurl }}/assets/logo_romeo.jpg" alt="Logo projet ROMEO"
             style="height: 70px;"/>
-          </a>
         </div>
         <div class="col-md-6" style="padding-top:0.5em; padding-bottom:0.5em;">
-          <a href="http://www.euroc-project.eu">
             <img title="EUROC project" id="euroc_logo" src="{{ site.baseurl }}/assets/logo_euroc.png" alt="Logo EUROC project"
             style="height: 70px;"/>
-          </a>
         </div>
       </div>
       <div class="row">
         <div class="col-md-6" style="padding-top:0.5em; padding-bottom:0.5em;">
-          <a href="http://erc.europa.eu/projects-and-results/erc-funded-projects/actanthrope">
             <img title="ERC Actanthrope" id="ercactanthrope_logo" src="{{ site.baseurl }}/assets/LOGO_ERC.jpg" alt="Logo ERC"
             style="height: 110px;"/>
-          </a>
         </div>
         <div class="col-md-6" style="padding-top:0.5em; padding-bottom:0.5em;">
-          <a href="http://www.factory-in-a-day.eu/">
             <img title="Factory in a Day" id="factory-in-a-day_logo" src="{{ site.baseurl }}/assets/logo_fiad.jpg" alt="EU Project: Factory-in-a-day"
             style="height: 110px;"/>
-          </a>
         </div>
       </div>
       <div class="row">
@@ -59,10 +51,8 @@ layout: home
     </div>
     <div class="col-md-2 text-center">
       <div class="row">
-       <a href="https://ec.europa.eu/research/fp7/index_en.cfm">
           <img title="Framework Program 7" id="FP7_logo" src="{{ site.baseurl }}/assets/logo-FP7.jpg" alt="Framework Program 7"
           style="height: 110px;"/>
-        </a>
       </div>
       <div class="row">
         <a href="http://www.agence-nationale-recherche.fr">
@@ -71,10 +61,8 @@ layout: home
         </a>
       </div>
       <div class="row">
-        <a href="http://robocomplusplus.eu/">
           <img title="RoboCom++" id="robocom++_logo" src="{{ site.baseurl }}/assets/logo_robocom_def_png.png" alt="RoboCom++"
           style="height: 110px;"/>
-        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
For some reason, videos on peertube are not displayed in the front page of the documentation eventhough I use the embed link. I removed them and added the construction set example from youtube.